### PR TITLE
Debug org-wide YAML issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/MARKDOWNYAML.md
+++ b/.github/ISSUE_TEMPLATE/MARKDOWNYAML.md
@@ -1,0 +1,63 @@
+name: "💡 MARKDOWN .github YAML form"
+description: [DEBUGGING IGNORE] Create a new ticket for a new feature request
+title: "💡 [REQUEST] - <title>"
+labels: [
+  "question"
+]
+body:
+  - type: input
+    id: start_date
+    attributes:
+      label: "Start Date"
+      description: Start of development
+      placeholder: "day/month/year"
+    validations:
+      required: false
+  - type: textarea
+    id: implementation_pr
+    attributes:
+      label: "Implementation PR"
+      description: Pull request used
+      placeholder: "#Pull Request ID"
+    validations:
+      required: false
+  - type: textarea
+    id: reference_issues
+    attributes:
+      label: "Reference Issues"
+      description: Common issues
+      placeholder: "#Issues IDs"
+    validations:
+      required: false
+  - type: textarea
+    id: summary
+    attributes:
+      label: "Summary"
+      description: Provide a brief explanation of the feature
+      placeholder: Describe in a few lines your feature request
+    validations:
+      required: true
+  - type: textarea
+    id: basic_example
+    attributes:
+      label: "Basic Example"
+      description: Indicate here some basic examples of your feature.
+      placeholder: A few specific words about your feature request.
+    validations:
+      required: true
+  - type: textarea
+    id: drawbacks
+    attributes:
+      label: "Drawbacks"
+      description: What are the drawbacks/impacts of your feature request ?
+      placeholder: Identify the drawbacks and impacts while being neutral on your feature request
+    validations:
+      required: true
+  - type: textarea
+    id: unresolved_question
+    attributes:
+      label: "Unresolved questions"
+      description: What questions still remain unresolved ?
+      placeholder: Identify any unresolved issues.
+    validations:
+      required: false


### PR DESCRIPTION
This attempts to add a YAML template as a Markdown typed file

Expectation
- It's offered across repos (private + public) as Markdown (broken deluxe)

Weird expectation
- It actually works

Possible outcome
- GH gets a hick-up and nothing is visible

- see #85 in collab repo

@lauranolling - trying around a bit here.